### PR TITLE
ユーザー登録関数でuserNameやgroupNameが空の時＆userNameがGithubに存在しない場合のエラーハンドリングを追加

### DIFF
--- a/src/UserRegisterFunction/main.go
+++ b/src/UserRegisterFunction/main.go
@@ -84,6 +84,28 @@ func handler(request events.APIGatewayProxyRequest) (events.APIGatewayProxyRespo
         }, err
     }
 
+	// userNameとgroupNameが空の場合はエラーを返す
+	if user.UserName == "" || user.GroupName == "" {
+		fmt.Println("userName or groupName is empty")
+		return events.APIGatewayProxyResponse{
+            Body:       "userName or groupName is empty",
+            StatusCode: 401,
+        }, nil
+	}
+
+	// TODO: GitHubのアクセストークンで確認するように変更する
+	// GitHubにアクセスしてユーザー名が存在するか確認
+	err = common.AccessGitHubWithUserName(user.UserName)
+
+	// userNameがGitHubにない場合はエラーを返す
+	if err != nil {
+		fmt.Println(err.Error())
+		return events.APIGatewayProxyResponse{
+            Body:       err.Error(),
+            StatusCode: 401,
+        }, nil
+	}
+
 	// dynamodbにデータを挿入
 	err = putItemToDynamoDB(&user)
 

--- a/src/common/main.go
+++ b/src/common/main.go
@@ -2,7 +2,9 @@ package common
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net/http"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -52,4 +54,21 @@ func CreateDynamoDBClient() (*dynamodb.Client, error) {
     client := dynamodb.NewFromConfig(cfg)
 
 	return client, nil
+}
+
+// GitHubにアクセスしてユーザー名が存在するか確認する
+func AccessGitHubWithUserName(userName string) error {
+	urlAddress := "https://github-contributions-api.deno.dev/" + userName + ".text"
+
+	req, _ := http.NewRequest(http.MethodGet, urlAddress, nil)
+	client := new(http.Client)
+	resp, _ := client.Do(req)
+
+	if resp.StatusCode != 200 {
+		err := errors.New("userName is not found in GitHub")
+
+		return err
+	}
+
+	return nil
 }


### PR DESCRIPTION
ユーザー登録関数でuserNameやgroupNameが空の時＆userNameがGithubに存在しない場合のエラーハンドリングを追加